### PR TITLE
Fix: Prevent user from hiding/unhinding apps if the configured hider is not available

### DIFF
--- a/app/src/main/java/deltazero/amarok/Hider.java
+++ b/app/src/main/java/deltazero/amarok/Hider.java
@@ -1,5 +1,6 @@
 package deltazero.amarok;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
@@ -62,7 +63,10 @@ public final class Hider {
                 processHide(context);
                 return;
             }
-            showNoHiderDialog(context, msg);
+            if (context instanceof Activity)
+                showNoHiderDialog(context, msg);
+            else
+                showNoHiderToast(context, msg);
         });
     }
 
@@ -98,7 +102,10 @@ public final class Hider {
                 processUnhide(context);
                 return;
             }
-            showNoHiderDialog(context, msg);
+            if (context instanceof Activity)
+                showNoHiderDialog(context, msg);
+            else
+                showNoHiderToast(context, msg);
         });
     }
 
@@ -146,6 +153,10 @@ public final class Hider {
                         -> context.startActivity(new Intent(context, SwitchAppHiderActivity.class)))
                 .setNegativeButton(context.getString(R.string.ok), null)
                 .show();
+    }
+
+    private static void showNoHiderToast(Context context, int message) {
+        Toast.makeText(context, message, Toast.LENGTH_LONG).show();
     }
 
 }

--- a/app/src/main/java/deltazero/amarok/Hider.java
+++ b/app/src/main/java/deltazero/amarok/Hider.java
@@ -1,6 +1,7 @@
 package deltazero.amarok;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
@@ -8,6 +9,9 @@ import android.util.Log;
 import android.widget.Toast;
 
 import androidx.lifecycle.MutableLiveData;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import deltazero.amarok.ui.settings.SwitchAppHiderActivity;
 
 
 public final class Hider {
@@ -53,6 +57,16 @@ public final class Hider {
     }
 
     public static void hide(Context context) {
+        PrefMgr.getAppHider(context).tryToActivate((appHiderClass, succeed, msg) -> {
+            if (succeed) {
+                processHide(context);
+                return;
+            }
+            showNoHiderDialog(context, msg);
+        });
+    }
+
+    private static void processHide(Context context) {
 
         threadHandler.post(() -> {
 
@@ -79,6 +93,16 @@ public final class Hider {
     }
 
     public static void unhide(Context context) {
+        PrefMgr.getAppHider(context).tryToActivate((appHiderClass, succeed, msg) -> {
+            if (succeed) {
+                processUnhide(context);
+                return;
+            }
+            showNoHiderDialog(context, msg);
+        });
+    }
+
+    private static void processUnhide(Context context) {
 
         threadHandler.post(() -> {
 
@@ -112,6 +136,16 @@ public final class Hider {
             hiderThread.interrupt();
         PrefMgr.setIsHidden(true);
         unhide(context);
+    }
+
+    public static void showNoHiderDialog(Context context, int message) {
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.apphider_not_ava_title)
+                .setMessage(message)
+                .setPositiveButton(R.string.switch_app_hider, (dialog, which)
+                        -> context.startActivity(new Intent(context, SwitchAppHiderActivity.class)))
+                .setNegativeButton(context.getString(R.string.ok), null)
+                .show();
     }
 
 }

--- a/app/src/main/java/deltazero/amarok/ui/MainActivity.java
+++ b/app/src/main/java/deltazero/amarok/ui/MainActivity.java
@@ -79,13 +79,7 @@ public class MainActivity extends AmarokActivity {
         // Check Hiders availability
         PrefMgr.getAppHider(this).tryToActivate((appHiderClass, succeed, msg) -> {
             if (succeed) return;
-            new MaterialAlertDialogBuilder(this)
-                    .setTitle(R.string.apphider_not_ava_title)
-                    .setMessage(msg)
-                    .setPositiveButton(R.string.switch_app_hider, (dialog, which)
-                            -> startActivity(new Intent(this, SwitchAppHiderActivity.class)))
-                    .setNegativeButton(getString(R.string.ok), null)
-                    .show();
+            Hider.showNoHiderDialog(this, msg);
         });
 
         PrefMgr.getFileHider(this).tryToActive((fileHiderClass, succeed, msg) -> {

--- a/app/src/main/java/deltazero/amarok/ui/MainActivity.java
+++ b/app/src/main/java/deltazero/amarok/ui/MainActivity.java
@@ -79,7 +79,6 @@ public class MainActivity extends AmarokActivity {
         // Check Hiders availability
         PrefMgr.getAppHider(this).tryToActivate((appHiderClass, succeed, msg) -> {
             if (succeed) return;
-            PrefMgr.setAppHiderMode(NoneAppHider.class);
             new MaterialAlertDialogBuilder(this)
                     .setTitle(R.string.apphider_not_ava_title)
                     .setMessage(msg)


### PR DESCRIPTION
It creates a `isAvailable` method in all app hiders classes to check if the defined hider is ready to do it's job. Implements to check and allow toggle hide/unhide mode only if the app hider is available; if not, show the dialog to fix it. Also removes the default definition of app hider to `Disabled` when the previous one is not available, keeping the user defined one until the user itself changes it. 
- Fixes #211 